### PR TITLE
hiera_backend in krb5keytab::keytab is not correctly used

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,14 +1,20 @@
 {
   "name": "collectivemedia-krb5keytab",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "collectivemedia",
   "summary": "Generates and manages Kerberos host keytabs",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/collectivemedia/puppet-krb5keytab",
   "issues_url": "https://github.com/collectivemedia/puppet-krb5keytab/issues",
   "project_page": "https://github.com/collectivemedia/puppet-krb5keytab",
+  "operatingsystem_support": [
+    {
+      "operatingsystem":"CentOS",
+      "operatingsystemrelease": ["6.0"]
+    }
+  ], 
   "dependencies": [
-    {"version_requirement":">= 1.0.0","name":"puppetlabs-stdlib"}
+    {"version_requirement":">= 1.0.0","name":"puppetlabs/stdlib"}
   ]
 }
 


### PR DESCRIPTION
```
krb5keytab_saveinhiera( {
hiera_key => $hiera_key_used,
hiera_value => base64('encode', $keytab_from_generatekt),
fqdn => $::fqdn,
hiera_backend => $krb5keytab::hiera_backend,
hiera_file_dir => hiera('krb5keytab::hiera-file-dir', ''),
hiera_couchdb_hostname => hiera('krb5keytab::hiera-couchdb-hostname', '127.0.0.1'),
hiera_couchdb_port => hiera('krb5keytab::hiera-couchdb-port', '5984'),
hiera_couchdb_database => hiera('krb5keytab::hiera-couchdb-database', 'keytabs'),
hiera_couchdb_username => hiera('krb5keytab::hiera-couchdb-username', ''),
hiera_couchdb_password => hiera('krb5keytab::hiera-couchdb-password', ''),
} )
```

hiera_backend should use the value passed into this **define** not $krb5keytab::hiera_backend since host_keytab is deprecated.

A keytab yaml file is not created because of this, I don't mind fixing it
